### PR TITLE
Parse quoted parameters

### DIFF
--- a/src/Task.php
+++ b/src/Task.php
@@ -79,9 +79,19 @@ class Task extends TotemModel
             $parameters = collect($matches)->mapWithKeys(function ($parameter) use ($console, &$argument_index) {
                 $param = explode('=', $parameter[0]);
 
-                return count($param) > 1
-                    ? ($console ? (starts_with($param[0], '--') ? [$param[0] => $param[1]] : [$argument_index++ => $param[1]]) : [$param[0] => $param[1]])
-                    : (starts_with($param[0], '--') && ! $console ? [$param[0] => true] : [$argument_index++ => $param[0]]);
+                if(count($param) > 1) {
+                    $value = trim(trim($param[1], '"'), "'");
+                    if($console) {
+                        return starts_with($param[0], '--') ?
+                            [$param[0] => $value] :
+                            [$argument_index++ => $value];
+                    }
+                    return [$param[0] => $value];
+                }
+
+                return starts_with($param[0], '--') && ! $console ?
+                    [$param[0] => true] :
+                    [$argument_index++ => $param[0]];
             })->toArray();
 
             return $parameters;


### PR DESCRIPTION
Given parameters: `--url='https://noort.be' --header='Authorization: Basic XXX'` resulted in the values (for url and header) that were quoted. The PR proposed solves this by trimming the value for single and double quotes.